### PR TITLE
docs: SDV badges, citations, cross-linking + expanded tutorials

### DIFF
--- a/R/toa_api_key.R
+++ b/R/toa_api_key.R
@@ -23,6 +23,11 @@
 #' ```r
 #' Sys.setenv(ODDS_API_KEY = "XXXX-YOUR-API-KEY-HERE-XXXXX")
 #' ```
+#' @family The Odds API: Account & Usage
+#' @seealso [toa_quota()] to inspect your usage credits after any API call,
+#'   [toa_requests()] to explicitly query your remaining/used credits, and
+#'   [toa_sports()] to start exploring available sports. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @name register_toa
 NULL
 #' @rdname register_toa

--- a/R/toa_event_markets.R
+++ b/R/toa_event_markets.R
@@ -50,6 +50,11 @@
 #' @importFrom rlang .data
 #' @import tidyr
 #' @export
+#' @family The Odds API: Odds & Markets
+#' @seealso [toa_event_odds()] to pull odds for the market keys discovered here,
+#'   [toa_sports_odds()] for featured-market odds across all events, and
+#'   [toa_sports_events()] to look up `event_id` values. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_event_markets(sport_key = 'basketball_nba',
 #'                          event_id = '48db9c3293a52baab881d95d38f37a98',

--- a/R/toa_event_odds.R
+++ b/R/toa_event_odds.R
@@ -62,6 +62,11 @@
 #' @importFrom rlang .data
 #' @import tidyr
 #' @export
+#' @family The Odds API: Odds & Markets
+#' @seealso [toa_sports_odds()] for featured-market odds across all upcoming
+#'   events, [toa_event_markets()] to discover available market keys for an
+#'   event, and [toa_sports_events()] to look up `event_id` values. Part of
+#'   the \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_event_odds(sport_key = 'basketball_nba',
 #'                       event_id = '48db9c3293a52baab881d95d38f37a98',

--- a/R/toa_event_odds_history.R
+++ b/R/toa_event_odds_history.R
@@ -75,6 +75,11 @@
 #' @importFrom rlang .data
 #' @import tidyr
 #' @export
+#' @family The Odds API: Historical
+#' @seealso [toa_sports_events_history()] to look up historical `event_id`
+#'   values, [toa_sports_odds_history()] for featured-market odds across all
+#'   events at a snapshot, and [toa_event_odds()] for current event odds. Part
+#'   of the \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_event_odds_history(sport_key = 'basketball_nba',
 #'                               event_id = '93af4b300a4c0dded909234ea32e9abd',

--- a/R/toa_requests.R
+++ b/R/toa_requests.R
@@ -21,6 +21,11 @@
 #' @importFrom glue glue
 #' @importFrom rlang .data
 #' @export
+#' @family The Odds API: Account & Usage
+#' @seealso [toa_quota()] to read cached usage from the most recent call without
+#'   a network round-trip, [toa_key()] / [register_toa] to configure your API
+#'   key, and [toa_sports()] to start pulling data. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'   try(toa_requests())
 #' }

--- a/R/toa_sports.R
+++ b/R/toa_sports.R
@@ -28,6 +28,11 @@
 #' @importFrom glue glue
 #' @importFrom rlang .data
 #' @export
+#' @family The Odds API: Sports & Events
+#' @seealso [toa_sports_events()] to list upcoming events for a sport,
+#'   [toa_sports_scores()] for live/recent scores, and [toa_sports_odds()]
+#'   to pull featured-market odds. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'   try(toa_sports(all_sports = TRUE))
 #' }

--- a/R/toa_sports_events.R
+++ b/R/toa_sports_events.R
@@ -41,6 +41,11 @@
 #' @importFrom dplyr as_tibble
 #' @importFrom rlang .data
 #' @export
+#' @family The Odds API: Sports & Events
+#' @seealso [toa_sports()] to discover `sport_key` values, [toa_event_odds()]
+#'   to pull odds for a specific event by its `id`, and [toa_event_markets()]
+#'   to see available market keys per bookmaker. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_sports_events(sport_key = 'basketball_nba'))
 #' }

--- a/R/toa_sports_events_history.R
+++ b/R/toa_sports_events_history.R
@@ -52,6 +52,11 @@
 #' @importFrom dplyr as_tibble mutate
 #' @importFrom rlang .data
 #' @export
+#' @family The Odds API: Historical
+#' @seealso [toa_event_odds_history()] to pull odds for a historical event by
+#'   its `id`, [toa_sports_odds_history()] for featured-market odds at a
+#'   historical snapshot, and [toa_sports_events()] for current events. Part of
+#'   the \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_sports_events_history(sport_key = 'basketball_nba',
 #'                                  date = '2024-01-15T12:15:00Z'))

--- a/R/toa_sports_odds.R
+++ b/R/toa_sports_odds.R
@@ -55,6 +55,11 @@
 #' @importFrom rlang .data
 #' @import tidyr
 #' @export
+#' @family The Odds API: Odds & Markets
+#' @seealso [toa_event_odds()] for a single event's odds (including player props
+#'   and alternate lines), [toa_event_markets()] to list a game's available
+#'   market keys, and [toa_sports()] to find `sport_key` values. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_sports_odds(sport_key = 'basketball_nba',
 #'                        regions = 'us',

--- a/R/toa_sports_odds_history.R
+++ b/R/toa_sports_odds_history.R
@@ -71,6 +71,11 @@
 #' @importFrom rlang .data
 #' @import tidyr
 #' @export
+#' @family The Odds API: Historical
+#' @seealso [toa_event_odds_history()] for historical odds on a single event
+#'   (including player props), [toa_sports_events_history()] to list events at a
+#'   historical snapshot, and [toa_sports_odds()] for current featured-market
+#'   odds. Part of the \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_sports_odds_history(sport_key = 'basketball_nba',
 #'                                date = '2024-01-15T12:15:00Z',

--- a/R/toa_sports_participants.R
+++ b/R/toa_sports_participants.R
@@ -27,6 +27,10 @@
 #' @importFrom dplyr as_tibble mutate select any_of
 #' @importFrom rlang .data .env
 #' @export
+#' @family The Odds API: Sports & Events
+#' @seealso [toa_sports()] to discover `sport_key` values, [toa_sports_events()]
+#'   to list upcoming events, and [toa_sports_scores()] for live/recent scores.
+#'   Part of the \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_sports_participants(sport_key = 'basketball_nba'))
 #' }

--- a/R/toa_sports_scores.R
+++ b/R/toa_sports_scores.R
@@ -39,6 +39,10 @@
 #' @importFrom glue glue
 #' @importFrom rlang .data
 #' @export
+#' @family The Odds API: Sports & Events
+#' @seealso [toa_sports()] to discover `sport_key` values, [toa_sports_events()]
+#'   to list upcoming events, and [toa_sports_odds()] for live/upcoming betting
+#'   lines. Part of the \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'    try(toa_sports_scores(sport_key = 'basketball_nba',
 #'                          days_from = NULL,

--- a/R/utils.R
+++ b/R/utils.R
@@ -63,6 +63,11 @@ toa_api_request <- function(url, query = NULL, ...){
 #' @return A one-row tibble with columns `requests_remaining`, `requests_used`
 #'  and `requests_last`, or `NULL` if no API call has been made yet this session.
 #' @export
+#' @family The Odds API: Account & Usage
+#' @seealso [toa_requests()] to explicitly query usage via an API round-trip,
+#'   [toa_key()] / [register_toa] to set up your API key, and [toa_sports()]
+#'   for your first data call. Part of the
+#'   \href{https://sportsdataverse.org/}{SportsDataverse}.
 #' @examples \donttest{
 #'   try(toa_sports())
 #'   try(toa_quota())

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,15 +2,14 @@
 output: github_document
 ---
 
-#
-
 # **oddsapiR**  <a href='https://oddsapiR.sportsdataverse.org/'><img src='https://raw.githubusercontent.com/sportsdataverse/oddsapiR/main/logo.png' align="right" width="20%" min-width="100px"/></a>
 
 <!-- badges: start -->
+[![CRAN version](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=success&label=CRAN%20version&prefix=v&query=%24.Version&url=https%3A%2F%2Fcrandb.r-pkg.org%2FoddsapiR)](https://CRAN.R-project.org/package=oddsapiR)
+[![CRAN downloads](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=success&label=Downloads&query=%24%5B0%5D.downloads&url=https%3A%2F%2Fcranlogs.r-pkg.org%2Fdownloads%2Ftotal%2F2022-12-29%3Alast-day%2FoddsapiR)](https://CRAN.R-project.org/package=oddsapiR)
+[![R-universe version](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=success&label=R-universe&prefix=v&query=%24.Version&url=https%3A%2F%2Fsportsdataverse.r-universe.dev%2Fapi%2Fpackages%2FoddsapiR)](https://sportsdataverse.r-universe.dev/oddsapiR)
 [![Version-Number](https://img.shields.io/github/r-package/v/sportsdataverse/oddsapiR?label=oddsapiR&logo=R&style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR)
-[![R-CMD-check](https://img.shields.io/github/actions/workflow/status/sportsdataverse/oddsapiR/R-CMD-check.yaml?branch=main&label=R-CMD-Check&logo=R&logoColor=white&style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR/actions/workflows/R-CMD-check.yaml) [![Lifecycle:maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg?style=for-the-badge&logo=github)](https://github.com/sportsdataverse/oddsapiR)  [![Contributors](https://img.shields.io/github/contributors/sportsdataverse/oddsapiR?style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR/graphs/contributors) 
-[![Twitter Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=twitter&style=for-the-badge)](https://twitter.com/SportsDataverse) 
-
+[![R-CMD-check](https://img.shields.io/github/actions/workflow/status/sportsdataverse/oddsapiR/R-CMD-check.yaml?branch=main&label=R-CMD-Check&logo=R&logoColor=white&style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR/actions/workflows/R-CMD-check.yaml) [![Lifecycle:maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg?style=for-the-badge&logo=github)](https://github.com/sportsdataverse/oddsapiR)  [![Contributors](https://img.shields.io/github/contributors/sportsdataverse/oddsapiR?style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR/graphs/contributors) [![Twitter Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=x&style=for-the-badge)](https://twitter.com/SportsDataverse)
 <!-- badges: end -->
 
 ```{r setup, include = FALSE}
@@ -22,18 +21,19 @@ knitr::opts_chunk$set(
 )
 ```
 
-To access the API, get a free API key from https://the-odds-api.com
+[**`oddsapiR`**](https://oddsapiR.sportsdataverse.org/) is an R package for accessing live and historical sports betting odds, scores, events, and participants from [**The Odds API**](https://the-odds-api.com/) — spanning dozens of sports and 60+ bookmakers worldwide. Every endpoint returns a clean, tidy `data.frame`/`tibble` ready for analysis, built on a single `httr2`-based request layer with automatic API-key handling and usage-quota tracking.
 
-Installation & Usage
+Part of the [SportsDataverse](https://sportsdataverse.org/) family of R & Python packages for sports analytics. To access the API, get a free API key at <https://the-odds-api.com>.
 
 ## **Installation**
 
-<!-- You can install the CRAN version of [**```oddsapiR```** ](https://CRAN.R-project.org/package=oddsapiR) with: -->
-<!-- ```{r readme_cran_install, eval=FALSE} -->
-<!-- install.packages("oddsapiR") -->
-<!-- ``` -->
+You can install the CRAN version of [**`oddsapiR`**](https://CRAN.R-project.org/package=oddsapiR) with:
 
-You can install the released version of [**`oddsapiR`**](https://github.com/sportsdataverse/oddsapiR) from [GitHub](https://github.com/sportsdataverse/oddsapiR) with:
+```r
+install.packages("oddsapiR")
+```
+
+You can install the development version of [**`oddsapiR`**](https://github.com/sportsdataverse/oddsapiR) from [GitHub](https://github.com/sportsdataverse/oddsapiR) with:
 
 ```r
 # using the pak package (recommended):
@@ -94,9 +94,25 @@ Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%
 stars](https://img.shields.io/github/stars/sportsdataverse/oddsapiR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20oddsapiR&maxAge=2592000)](https://github.com/sportsdataverse/oddsapiR/stargazers/)
 
 
+## **The SportsDataverse**
+
+`oddsapiR` is part of the [**SportsDataverse**](https://sportsdataverse.org/), a family of open-source R, Python, and Node.js packages for sports data. Related packages you can pair odds data with:
+
+| Package | Sport / Scope |
+|---|---|
+| [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) | College football |
+| [**hoopR**](https://hoopR.sportsdataverse.org/) | Men's basketball (NBA & NCAA) |
+| [**wehoop**](https://wehoop.sportsdataverse.org/) | Women's basketball (WNBA & NCAA) |
+| [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) | Hockey (NHL & PWHL) |
+| [**baseballr**](https://billpetti.github.io/baseballr/) | Baseball (MLB, MiLB, NCAA) |
+| [**sportsdataverse-R**](https://r.sportsdataverse.org/) | Umbrella R metapackage |
+| [**sportsdataverse-py**](https://py.sportsdataverse.org/) · [**sportsdataverse.js**](https://js.sportsdataverse.org/) | Python & Node.js |
+
+See the full ecosystem at [sportsdataverse.org](https://sportsdataverse.org/).
+
 ## **Our Authors**
 
--   [Saiem Gilani](https://twitter.com/saiemgilani)       
+-   [Saiem Gilani](https://twitter.com/saiemgilani)
 <a href="https://twitter.com/saiemgilani" target="blank"><img src="https://img.shields.io/twitter/follow/saiemgilani?color=blue&label=%40saiemgilani&logo=twitter&style=for-the-badge" alt="@saiemgilani" /></a>
 <a href="https://github.com/saiemgilani" target="blank"><img src="https://img.shields.io/github/followers/saiemgilani?color=eee&logo=Github&style=for-the-badge" alt="@saiemgilani" /></a>
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,44 @@
 
-# 
-
 # **oddsapiR** <a href='https://oddsapiR.sportsdataverse.org/'><img src='https://raw.githubusercontent.com/sportsdataverse/oddsapiR/main/logo.png' align="right" width="20%" min-width="100px"/></a>
 
 <!-- badges: start -->
 
+[![CRAN
+version](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=success&label=CRAN%20version&prefix=v&query=%24.Version&url=https%3A%2F%2Fcrandb.r-pkg.org%2FoddsapiR)](https://CRAN.R-project.org/package=oddsapiR)
+[![CRAN
+downloads](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=success&label=Downloads&query=%24%5B0%5D.downloads&url=https%3A%2F%2Fcranlogs.r-pkg.org%2Fdownloads%2Ftotal%2F2022-12-29%3Alast-day%2FoddsapiR)](https://CRAN.R-project.org/package=oddsapiR)
+[![R-universe
+version](https://img.shields.io/badge/dynamic/json?style=for-the-badge&color=success&label=R-universe&prefix=v&query=%24.Version&url=https%3A%2F%2Fsportsdataverse.r-universe.dev%2Fapi%2Fpackages%2FoddsapiR)](https://sportsdataverse.r-universe.dev/oddsapiR)
 [![Version-Number](https://img.shields.io/github/r-package/v/sportsdataverse/oddsapiR?label=oddsapiR&logo=R&style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR)
 [![R-CMD-check](https://img.shields.io/github/actions/workflow/status/sportsdataverse/oddsapiR/R-CMD-check.yaml?branch=main&label=R-CMD-Check&logo=R&logoColor=white&style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR/actions/workflows/R-CMD-check.yaml)
 [![Lifecycle:maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg?style=for-the-badge&logo=github)](https://github.com/sportsdataverse/oddsapiR)
 [![Contributors](https://img.shields.io/github/contributors/sportsdataverse/oddsapiR?style=for-the-badge)](https://github.com/sportsdataverse/oddsapiR/graphs/contributors)
 [![Twitter
-Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=twitter&style=for-the-badge)](https://twitter.com/SportsDataverse)
-
+Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%40SportsDataverse&logo=x&style=for-the-badge)](https://twitter.com/SportsDataverse)
 <!-- badges: end -->
 
-To access the API, get a free API key from <https://the-odds-api.com>
+[**`oddsapiR`**](https://oddsapiR.sportsdataverse.org/) is an R package
+for accessing live and historical sports betting odds, scores, events,
+and participants from [**The Odds API**](https://the-odds-api.com/) —
+spanning dozens of sports and 60+ bookmakers worldwide. Every endpoint
+returns a clean, tidy `data.frame`/`tibble` ready for analysis, built on
+a single `httr2`-based request layer with automatic API-key handling and
+usage-quota tracking.
 
-Installation & Usage
+Part of the [SportsDataverse](https://sportsdataverse.org/) family of R
+& Python packages for sports analytics. To access the API, get a free
+API key at <https://the-odds-api.com>.
 
 ## **Installation**
 
-<!-- You can install the CRAN version of [**```oddsapiR```** ](https://CRAN.R-project.org/package=oddsapiR) with: -->
+You can install the CRAN version of
+[**`oddsapiR`**](https://CRAN.R-project.org/package=oddsapiR) with:
 
-<!-- ```{r readme_cran_install, eval=FALSE} -->
+``` r
+install.packages("oddsapiR")
+```
 
-<!-- install.packages("oddsapiR") -->
-
-<!-- ``` -->
-
-You can install the released version of
+You can install the development version of
 [**`oddsapiR`**](https://github.com/sportsdataverse/oddsapiR) from
 [GitHub](https://github.com/sportsdataverse/oddsapiR) with:
 
@@ -111,9 +121,29 @@ Follow](https://img.shields.io/twitter/follow/SportsDataverse?color=blue&label=%
 [![GitHub
 stars](https://img.shields.io/github/stars/sportsdataverse/oddsapiR.svg?color=eee&logo=github&style=for-the-badge&label=Star%20oddsapiR&maxAge=2592000)](https://github.com/sportsdataverse/oddsapiR/stargazers/)
 
+## **The SportsDataverse**
+
+`oddsapiR` is part of the
+[**SportsDataverse**](https://sportsdataverse.org/), a family of
+open-source R, Python, and Node.js packages for sports data. Related
+packages you can pair odds data with:
+
+| Package                                                                                                               | Sport / Scope                    |
+| --------------------------------------------------------------------------------------------------------------------- | -------------------------------- |
+| [**cfbfastR**](https://cfbfastR.sportsdataverse.org/)                                                                 | College football                 |
+| [**hoopR**](https://hoopR.sportsdataverse.org/)                                                                       | Men’s basketball (NBA & NCAA)    |
+| [**wehoop**](https://wehoop.sportsdataverse.org/)                                                                     | Women’s basketball (WNBA & NCAA) |
+| [**fastRhockey**](https://fastRhockey.sportsdataverse.org/)                                                           | Hockey (NHL & PWHL)              |
+| [**baseballr**](https://billpetti.github.io/baseballr/)                                                               | Baseball (MLB, MiLB, NCAA)       |
+| [**sportsdataverse-R**](https://r.sportsdataverse.org/)                                                               | Umbrella R metapackage           |
+| [**sportsdataverse-py**](https://py.sportsdataverse.org/) · [**sportsdataverse.js**](https://js.sportsdataverse.org/) | Python & Node.js                 |
+
+See the full ecosystem at
+[sportsdataverse.org](https://sportsdataverse.org/).
+
 ## **Our Authors**
 
-  - [Saiem Gilani](https://twitter.com/saiemgilani)  
+  - [Saiem Gilani](https://twitter.com/saiemgilani)
     <a href="https://twitter.com/saiemgilani" target="blank"><img src="https://img.shields.io/twitter/follow/saiemgilani?color=blue&label=%40saiemgilani&logo=twitter&style=for-the-badge" alt="@saiemgilani" /></a>
     <a href="https://github.com/saiemgilani" target="blank"><img src="https://img.shields.io/github/followers/saiemgilani?color=eee&logo=Github&style=for-the-badge" alt="@saiemgilani" /></a>
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -90,14 +90,10 @@ navbar:
         href: https://wehoop.sportsdataverse.org/
       - text: fastRhockey
         href: https://fastRhockey.sportsdataverse.org/
-      - text: hockeyR
-        href: https://hockeyr.netlify.app/
       - text: ggshakeR
         href: https://abhiamishra.github.io/ggshakeR/
       - text: baseballr
         href: https://BillPetti.github.io/baseballr/
-      - text: worldfootballR
-        href: https://jaseziv.github.io/worldfootballR/
       - text: usfootballR
         href: https://usfootballR.sportsdataverse.org/
       - text: soccerAnimate
@@ -108,8 +104,6 @@ navbar:
         href: https://oddsapiR.sportsdataverse.org/
       - text: sportyR
         href: https://sportyR.sportsdataverse.org/
-      - text: toRvik
-        href: https://torvik.dev/
       - text: cfbplotR
         href: https://cfbplotR.sportsdataverse.org/
       - text: mlbplotR
@@ -120,8 +114,6 @@ navbar:
         href: https://cfb4th.sportsdataverse.org/
       - text: nwslR
         href: https://github.com/nwslR/nwslR/
-      - text: gamezoneR
-        href: https://jacklich10.github.io/gamezoneR/
       - text: recruitR
         href: https://recruitr.sportsdataverse.org/
       - text: puntr
@@ -134,8 +126,6 @@ navbar:
         href: https://sportypy.sportsdataverse.org/
       - text: nwslpy
         href: https://github.com/nwslR/nwslpy/
-      - text: recruitR-py
-        href: https://github.com/sportsdataverse/recruitR-py/
       - text: collegebaseball
         href: https://github.com/nathanblumenfeld/collegebaseball/
       - text: --------------------------------

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -66,6 +66,8 @@ navbar:
         href: articles/index.html
       - text: oddsapiR beginner's guide
         href: articles/oddsapiR.html
+      - text: Building a sports-odds pipeline
+        href: articles/building-an-odds-pipeline.html
     news:
       icon: "fas fa-newspaper"
       text: " News"
@@ -77,7 +79,7 @@ navbar:
       - text: SportsDataverse
         href: https://sportsdataverse.org/
       - text: --------------------------------
-      - text: R Packages
+      - text: "R Packages"
       - text: sportsdataverse-R
         href: https://r.sportsdataverse.org/
       - text: cfbfastR
@@ -86,36 +88,58 @@ navbar:
         href: https://hoopR.sportsdataverse.org/
       - text: wehoop
         href: https://wehoop.sportsdataverse.org/
-      - text: toRvik
-        href: https://torvik.dev/
       - text: fastRhockey
         href: https://fastRhockey.sportsdataverse.org/
+      - text: hockeyR
+        href: https://hockeyr.netlify.app/
+      - text: ggshakeR
+        href: https://abhiamishra.github.io/ggshakeR/
       - text: baseballr
         href: https://BillPetti.github.io/baseballr/
       - text: worldfootballR
         href: https://jaseziv.github.io/worldfootballR/
+      - text: usfootballR
+        href: https://usfootballR.sportsdataverse.org/
+      - text: soccerAnimate
+        href: https://github.com/Dato-Futbol/soccerAnimate/
       - text: chessR
         href: https://jaseziv.github.io/chessR/
+      - text: oddsapiR
+        href: https://oddsapiR.sportsdataverse.org/
       - text: sportyR
         href: https://sportyR.sportsdataverse.org/
+      - text: toRvik
+        href: https://torvik.dev/
       - text: cfbplotR
-        href: https://kazink36.github.io/cfbplotR/
-      - text: cfb4th
-        href: https://kazink36.github.io/cfb4th/
+        href: https://cfbplotR.sportsdataverse.org/
       - text: mlbplotR
-        href: https://github.com/camdenk/mlbplotR
-      - text: recruitR
-        href: https://recruitr.sportsdataverse.org/
+        href: https://camdenk.github.io/mlbplotR/
+      - text: softballR
+        href: https://github.com/sportsdataverse/softballR/
+      - text: cfb4th
+        href: https://cfb4th.sportsdataverse.org/
+      - text: nwslR
+        href: https://github.com/nwslR/nwslR/
       - text: gamezoneR
         href: https://jacklich10.github.io/gamezoneR/
+      - text: recruitR
+        href: https://recruitr.sportsdataverse.org/
       - text: puntr
         href: https://puntalytics.github.io/puntr/
       - text: --------------------------------
-      - text: Python Packages
+      - text: "Python Packages"
       - text: sportsdataverse-py
         href: https://py.sportsdataverse.org/
+      - text: sportypy
+        href: https://sportypy.sportsdataverse.org/
+      - text: nwslpy
+        href: https://github.com/nwslR/nwslpy/
+      - text: recruitR-py
+        href: https://github.com/sportsdataverse/recruitR-py/
+      - text: collegebaseball
+        href: https://github.com/nathanblumenfeld/collegebaseball/
       - text: --------------------------------
-      - text: Node.js Packages
+      - text: "Node.js Packages"
       - text: sportsdataverse.js
         href: https://js.sportsdataverse.org/
       - text: nfl-nerd

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,16 +1,18 @@
-year <- sub("-.*", "", meta$Date)
+## DESCRIPTION carries no Date field, so fall back to the build year.
+year <- if (!is.null(meta$Date)) sub("-.*", "", meta$Date) else format(Sys.Date(), "%Y")
 note <- sprintf("R package version %s", meta$Version)
 
-citHeader("To cite the oddsapiR R package in publications, use:")
-
-citEntry(entry = "Misc",
-         author = personList(as.person("Saiem Gilani")),
-         title = "oddsapiR: The SportsDataverse's R Package for The Odds API.",
-         url = c("https://oddsapiR.sportsdataverse.org"),
-         year = year,
-         note = note,
-         textVersion = paste(
-    "Saiem Gilani. oddsapiR: The SportsDataverse's R Package for The Odds API.",
-    "Retrieved from https://oddsapiR.sportsdataverse.org"
+bibentry(
+  bibtype  = "Misc",
+  header   = "To cite the oddsapiR R package in publications, use:",
+  key      = "gilani_oddsapiR",
+  author   = c(person("Saiem", "Gilani")),
+  title    = "oddsapiR: The SportsDataverse's R Package for The Odds API.",
+  url      = "https://oddsapiR.sportsdataverse.org",
+  year     = year,
+  note     = note,
+  textVersion = paste0(
+    "Saiem Gilani (", year, "). oddsapiR: The SportsDataverse's R Package for ",
+    "The Odds API. ", note, ". Retrieved from https://oddsapiR.sportsdataverse.org"
   )
 )

--- a/man/register_toa.Rd
+++ b/man/register_toa.Rd
@@ -45,3 +45,14 @@ using a command like the following.
 \if{html}{\out{<div class="sourceCode r">}}\preformatted{Sys.setenv(ODDS_API_KEY = "XXXX-YOUR-API-KEY-HERE-XXXXX")
 }\if{html}{\out{</div>}}
 }
+\seealso{
+\code{\link[=toa_quota]{toa_quota()}} to inspect your usage credits after any API call,
+\code{\link[=toa_requests]{toa_requests()}} to explicitly query your remaining/used credits, and
+\code{\link[=toa_sports]{toa_sports()}} to start exploring available sports. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Account & Usage: 
+\code{\link{toa_quota}()},
+\code{\link{toa_requests}()}
+}
+\concept{The Odds API: Account & Usage}

--- a/man/toa_event_markets.Rd
+++ b/man/toa_event_markets.Rd
@@ -69,4 +69,15 @@ returned \code{market_key} values to request odds via \code{\link[=toa_event_odd
                          regions = 'us'))
 }
 }
+\seealso{
+\code{\link[=toa_event_odds]{toa_event_odds()}} to pull odds for the market keys discovered here,
+\code{\link[=toa_sports_odds]{toa_sports_odds()}} for featured-market odds across all events, and
+\code{\link[=toa_sports_events]{toa_sports_events()}} to look up \code{event_id} values. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Odds & Markets: 
+\code{\link{toa_event_odds}()},
+\code{\link{toa_sports_odds}()}
+}
+\concept{The Odds API: Odds & Markets}
 \keyword{Markets}

--- a/man/toa_event_odds.Rd
+++ b/man/toa_event_odds.Rd
@@ -88,5 +88,16 @@ available market key, including player props and alternate lines. Look up an
                       date_format = 'iso'))
 }
 }
+\seealso{
+\code{\link[=toa_sports_odds]{toa_sports_odds()}} for featured-market odds across all upcoming
+events, \code{\link[=toa_event_markets]{toa_event_markets()}} to discover available market keys for an
+event, and \code{\link[=toa_sports_events]{toa_sports_events()}} to look up \code{event_id} values. Part of
+the \href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Odds & Markets: 
+\code{\link{toa_event_markets}()},
+\code{\link{toa_sports_odds}()}
+}
+\concept{The Odds API: Odds & Markets}
 \keyword{Betting}
 \keyword{Lines}

--- a/man/toa_event_odds_history.Rd
+++ b/man/toa_event_odds_history.Rd
@@ -103,5 +103,16 @@ with no data do not count against the quota.
                               date_format = 'iso'))
 }
 }
+\seealso{
+\code{\link[=toa_sports_events_history]{toa_sports_events_history()}} to look up historical \code{event_id}
+values, \code{\link[=toa_sports_odds_history]{toa_sports_odds_history()}} for featured-market odds across all
+events at a snapshot, and \code{\link[=toa_event_odds]{toa_event_odds()}} for current event odds. Part
+of the \href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Historical: 
+\code{\link{toa_sports_events_history}()},
+\code{\link{toa_sports_odds_history}()}
+}
+\concept{The Odds API: Historical}
 \keyword{Betting}
 \keyword{Lines}

--- a/man/toa_quota.Rd
+++ b/man/toa_quota.Rd
@@ -30,3 +30,14 @@ by a \verb{toa_*()} function, and are echoed when the tibble is printed.
   try(toa_quota())
 }
 }
+\seealso{
+\code{\link[=toa_requests]{toa_requests()}} to explicitly query usage via an API round-trip,
+\code{\link[=toa_key]{toa_key()}} / \link{register_toa} to set up your API key, and \code{\link[=toa_sports]{toa_sports()}}
+for your first data call. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Account & Usage: 
+\code{\link{register_toa}},
+\code{\link{toa_requests}()}
+}
+\concept{The Odds API: Account & Usage}

--- a/man/toa_requests.Rd
+++ b/man/toa_requests.Rd
@@ -27,4 +27,15 @@ against the free \verb{/v4/sports} endpoint, so it does not consume any quota.
   try(toa_requests())
 }
 }
+\seealso{
+\code{\link[=toa_quota]{toa_quota()}} to read cached usage from the most recent call without
+a network round-trip, \code{\link[=toa_key]{toa_key()}} / \link{register_toa} to configure your API
+key, and \code{\link[=toa_sports]{toa_sports()}} to start pulling data. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Account & Usage: 
+\code{\link{register_toa}},
+\code{\link{toa_quota}()}
+}
+\concept{The Odds API: Account & Usage}
 \keyword{Usage}

--- a/man/toa_sports.Rd
+++ b/man/toa_sports.Rd
@@ -35,4 +35,16 @@ Returns a list of in-season sports. The \code{key} returned here is the
   try(toa_sports(all_sports = TRUE))
 }
 }
+\seealso{
+\code{\link[=toa_sports_events]{toa_sports_events()}} to list upcoming events for a sport,
+\code{\link[=toa_sports_scores]{toa_sports_scores()}} for live/recent scores, and \code{\link[=toa_sports_odds]{toa_sports_odds()}}
+to pull featured-market odds. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Sports & Events: 
+\code{\link{toa_sports_events}()},
+\code{\link{toa_sports_participants}()},
+\code{\link{toa_sports_scores}()}
+}
+\concept{The Odds API: Sports & Events}
 \keyword{Sports}

--- a/man/toa_sports_events.Rd
+++ b/man/toa_sports_events.Rd
@@ -59,4 +59,16 @@ Returns a list of events without odds. The \code{id} returned here is the
    try(toa_sports_events(sport_key = 'basketball_nba'))
 }
 }
+\seealso{
+\code{\link[=toa_sports]{toa_sports()}} to discover \code{sport_key} values, \code{\link[=toa_event_odds]{toa_event_odds()}}
+to pull odds for a specific event by its \code{id}, and \code{\link[=toa_event_markets]{toa_event_markets()}}
+to see available market keys per bookmaker. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Sports & Events: 
+\code{\link{toa_sports}()},
+\code{\link{toa_sports_participants}()},
+\code{\link{toa_sports_scores}()}
+}
+\concept{The Odds API: Sports & Events}
 \keyword{Events}

--- a/man/toa_sports_events_history.Rd
+++ b/man/toa_sports_events_history.Rd
@@ -73,4 +73,15 @@ Historical data is available on paid usage plans from June 2020.
                                  date = '2024-01-15T12:15:00Z'))
 }
 }
+\seealso{
+\code{\link[=toa_event_odds_history]{toa_event_odds_history()}} to pull odds for a historical event by
+its \code{id}, \code{\link[=toa_sports_odds_history]{toa_sports_odds_history()}} for featured-market odds at a
+historical snapshot, and \code{\link[=toa_sports_events]{toa_sports_events()}} for current events. Part of
+the \href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Historical: 
+\code{\link{toa_event_odds_history}()},
+\code{\link{toa_sports_odds_history}()}
+}
+\concept{The Odds API: Historical}
 \keyword{Events}

--- a/man/toa_sports_odds.Rd
+++ b/man/toa_sports_odds.Rd
@@ -78,5 +78,16 @@ markets, use \code{\link[=toa_event_odds]{toa_event_odds()}} instead.
                        date_format = 'iso'))
 }
 }
+\seealso{
+\code{\link[=toa_event_odds]{toa_event_odds()}} for a single event's odds (including player props
+and alternate lines), \code{\link[=toa_event_markets]{toa_event_markets()}} to list a game's available
+market keys, and \code{\link[=toa_sports]{toa_sports()}} to find \code{sport_key} values. Part of the
+\href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Odds & Markets: 
+\code{\link{toa_event_markets}()},
+\code{\link{toa_event_odds}()}
+}
+\concept{The Odds API: Odds & Markets}
 \keyword{Betting}
 \keyword{Lines}

--- a/man/toa_sports_odds_history.Rd
+++ b/man/toa_sports_odds_history.Rd
@@ -99,5 +99,16 @@ Snapshots with no events do not count against the quota.
                                date_format = 'iso'))
 }
 }
+\seealso{
+\code{\link[=toa_event_odds_history]{toa_event_odds_history()}} for historical odds on a single event
+(including player props), \code{\link[=toa_sports_events_history]{toa_sports_events_history()}} to list events at a
+historical snapshot, and \code{\link[=toa_sports_odds]{toa_sports_odds()}} for current featured-market
+odds. Part of the \href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Historical: 
+\code{\link{toa_event_odds_history}()},
+\code{\link{toa_sports_events_history}()}
+}
+\concept{The Odds API: Historical}
 \keyword{Betting}
 \keyword{Lines}

--- a/man/toa_sports_participants.Rd
+++ b/man/toa_sports_participants.Rd
@@ -33,4 +33,15 @@ return individual players on a team.
    try(toa_sports_participants(sport_key = 'basketball_nba'))
 }
 }
+\seealso{
+\code{\link[=toa_sports]{toa_sports()}} to discover \code{sport_key} values, \code{\link[=toa_sports_events]{toa_sports_events()}}
+to list upcoming events, and \code{\link[=toa_sports_scores]{toa_sports_scores()}} for live/recent scores.
+Part of the \href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Sports & Events: 
+\code{\link{toa_sports}()},
+\code{\link{toa_sports_events}()},
+\code{\link{toa_sports_scores}()}
+}
+\concept{The Odds API: Sports & Events}
 \keyword{Participants}

--- a/man/toa_sports_scores.Rd
+++ b/man/toa_sports_scores.Rd
@@ -52,4 +52,15 @@ when \code{days_from} is supplied.
                          date_format = 'iso'))
 }
 }
+\seealso{
+\code{\link[=toa_sports]{toa_sports()}} to discover \code{sport_key} values, \code{\link[=toa_sports_events]{toa_sports_events()}}
+to list upcoming events, and \code{\link[=toa_sports_odds]{toa_sports_odds()}} for live/upcoming betting
+lines. Part of the \href{https://sportsdataverse.org/}{SportsDataverse}.
+
+Other The Odds API: Sports & Events: 
+\code{\link{toa_sports}()},
+\code{\link{toa_sports_events}()},
+\code{\link{toa_sports_participants}()}
+}
+\concept{The Odds API: Sports & Events}
 \keyword{Scores}

--- a/vignettes/articles/building-an-odds-pipeline.Rmd
+++ b/vignettes/articles/building-an-odds-pipeline.Rmd
@@ -1,0 +1,517 @@
+---
+title: "Building a sports-odds pipeline with oddsapiR"
+author: "Saiem Gilani"
+opengraph:
+  image:
+    src: "https://github.com/saiemgilani/oddsapiR/blob/main/logo.png?raw=true"
+  twitter:
+    card: summary
+    creator: "@saiemgilani"
+output: html_document
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  eval = FALSE
+)
+```
+
+This article walks through a realistic end-to-end pipeline for collecting, tidying, analysing, and persisting sports-odds data using `oddsapiR`. Every chunk that calls the live API is `eval = FALSE`; prose and comments describe realistic output shapes.
+
+The companion beginner guide lives at [oddsapiR: Getting started](../oddsapiR.html).
+
+```{r load_packages}
+library(oddsapiR)
+library(dplyr)
+library(tidyr)
+library(lubridate)
+library(ggplot2)
+library(gt)
+library(DBI)
+library(RSQLite)
+```
+
+
+## 1. Setup — key handling and budgeting your quota
+
+Before pulling any odds, check that a key is configured and inspect the current quota balance. [`toa_requests()`](https://oddsapiR.sportsdataverse.org/reference/toa_requests.html) hits the free `/v4/sports` endpoint, which does not consume a credit, and returns your balance as a one-row tibble.
+
+```{r setup_quota}
+# Confirm the key is present (errors loudly if not)
+check_toa_key()
+
+# Budget check: how many credits remain before we start pulling?
+budget_before <- toa_requests()
+budget_before
+# # A tibble: 1 x 2
+#   requests_remaining requests_used
+#                <int>         <int>
+#                  480            20
+```
+
+After each pull, call [`toa_quota()`](https://oddsapiR.sportsdataverse.org/reference/toa_quota.html) to read the headers cached from the most recent response without making a new network request:
+
+```{r check_quota_after}
+toa_quota()
+# # A tibble: 1 x 3
+#   requests_remaining requests_used requests_last
+#                <int>         <int>         <int>
+#                  477            23             3
+```
+
+The `requests_last` column tells you exactly how many credits the last call consumed. This is the correct way to audit costs during development: pull once, inspect `toa_quota()`, then multiply out your full pipeline's total cost before scheduling it.
+
+
+## 2. Discover — find active sports and upcoming events
+
+### Find active sport keys
+
+[`toa_sports()`](https://oddsapiR.sportsdataverse.org/reference/toa_sports.html) lists every sport the API covers. It is free. Filter to `active == TRUE` for sports that are currently in season:
+
+```{r discover_sports}
+all_sports <- toa_sports(all_sports = TRUE)
+
+# Sports currently in season
+in_season <- all_sports %>%
+  filter(active) %>%
+  select(key, group, title)
+
+in_season
+# key                      group              title
+# basketball_nba           Basketball         NBA
+# americanfootball_nfl     American Football  NFL
+# soccer_epl               Soccer             EPL
+# icehockey_nhl            Ice Hockey         NHL
+# ...
+```
+
+The `key` column is the `sport_key` argument for every downstream function. The bundled dataset [`toa_sports_keys`](https://oddsapiR.sportsdataverse.org/reference/toa_sports_keys.html) provides the same mapping without a network call:
+
+```{r bundled_keys, eval=TRUE}
+head(oddsapiR::toa_sports_keys, 10)
+```
+
+### List upcoming events for a sport
+
+[`toa_sports_events()`](https://oddsapiR.sportsdataverse.org/reference/toa_sports_events.html) lists in-play and pre-match events without odds. Also free. The `id` column is the `event_id` used by `toa_event_odds()` and `toa_event_markets()`.
+
+```{r discover_events}
+# Events for the next 24 hours
+now      <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+tomorrow <- format(Sys.time() + 86400, "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+
+nba_events <- toa_sports_events(
+  sport_key          = "basketball_nba",
+  date_format        = "iso",
+  commence_time_from = now,
+  commence_time_to   = tomorrow
+)
+
+nba_events
+# # A tibble: 6 x 6
+#   id                               sport_key       sport_title commence_time         home_team           away_team
+#   <chr>                            <chr>           <chr>       <chr>                 <chr>               <chr>
+# 1 48db9c3293a52baab881d95d38f37a98 basketball_nba  NBA         2025-01-15T00:10:00Z  Los Angeles Lakers  Boston Celtics
+# 2 9a1c3f2e8b7d4e5f6c0a2b3d4e5f6a7b basketball_nba  NBA         2025-01-15T01:00:00Z  Golden State Warriors Milwaukee Bucks
+# ...
+```
+
+### List participants (teams) for a sport
+
+[`toa_sports_participants()`](https://oddsapiR.sportsdataverse.org/reference/toa_sports_participants.html) returns the whitelist of teams or individual competitors. Cost: 1 credit.
+
+```{r discover_participants}
+nba_teams <- toa_sports_participants(sport_key = "basketball_nba")
+
+nba_teams
+# # A tibble: 30 x 3
+#   sport_key       id                              full_name
+#   <chr>           <chr>                           <chr>
+# 1 basketball_nba  par_01hqmkq6fdf1pvq7jgdd7hdmpf  Los Angeles Lakers
+# 2 basketball_nba  par_01hqmkq6fdf1pvq7jgdd7hdmpe  Boston Celtics
+# ...
+```
+
+
+## 3. Pull odds across bookmakers
+
+### Featured markets for an entire sport
+
+[`toa_sports_odds()`](https://oddsapiR.sportsdataverse.org/reference/toa_sports_odds.html) returns a **long-format** tibble — one row per (event, bookmaker, market, outcome). The cost equals `markets × regions`.
+
+```{r pull_sports_odds}
+# Pull moneyline + spreads + totals from US books
+# Cost: 3 markets x 1 region = 3 credits
+nba_odds <- toa_sports_odds(
+  sport_key   = "basketball_nba",
+  regions     = "us",
+  markets     = "h2h,spreads,totals",
+  odds_format = "decimal",
+  date_format = "iso"
+)
+
+glimpse(nba_odds)
+# Rows: ~360  (6 games x ~5 bookmakers x 3 markets x 2 outcomes per market)
+# Columns: id, sport_key, sport_title, commence_time, home_team, away_team,
+#           bookmaker_key, bookmaker, bookmaker_last_update,
+#           market_key, market_last_update, outcomes_name, outcomes_price,
+#           outcomes_point
+
+toa_quota()
+# requests_remaining = 477, requests_used = 23, requests_last = 3
+```
+
+### Detailed props for a single game
+
+[`toa_event_markets()`](https://oddsapiR.sportsdataverse.org/reference/toa_event_markets.html) lists every market key a bookmaker has opened for a game (1 credit). Then [`toa_event_odds()`](https://oddsapiR.sportsdataverse.org/reference/toa_event_odds.html) fetches the odds for specific market keys. Cost = unique markets returned × regions.
+
+```{r pull_event_odds}
+game_id <- "48db9c3293a52baab881d95d38f37a98"  # from toa_sports_events()
+
+# Discover available markets for this game (1 credit)
+available_markets <- toa_event_markets(
+  sport_key = "basketball_nba",
+  event_id  = game_id,
+  regions   = "us"
+)
+
+available_markets %>%
+  distinct(bookmaker, market_key) %>%
+  arrange(bookmaker, market_key)
+# bookmaker    market_key
+# DraftKings   h2h
+# DraftKings   player_points
+# DraftKings   player_rebounds
+# DraftKings   spreads
+# DraftKings   totals
+# FanDuel      h2h
+# FanDuel      player_points
+# ...
+
+# Fetch player-points props (cost: 1 market x 1 region = 1 credit)
+player_pts <- toa_event_odds(
+  sport_key   = "basketball_nba",
+  event_id    = game_id,
+  regions     = "us",
+  markets     = "player_points",
+  odds_format = "decimal",
+  date_format = "iso"
+)
+
+player_pts %>%
+  select(bookmaker, outcomes_name, outcomes_description, outcomes_price, outcomes_point) %>%
+  head(10)
+# bookmaker    outcomes_name  outcomes_description  outcomes_price  outcomes_point
+# DraftKings   Over           LeBron James          1.91            25.5
+# DraftKings   Under          LeBron James          1.91            25.5
+# FanDuel      Over           LeBron James          1.87            25.5
+# FanDuel      Under          LeBron James          1.95            25.5
+```
+
+
+## 4. Tidy and analyse: de-vig, implied probability, line shopping
+
+The raw data from `toa_sports_odds()` is already tidy (one row per outcome), but some light wrangling makes analysis easier.
+
+### De-duplicate and compute implied probability
+
+For two-sided markets (spreads, totals) each game has **two rows per bookmaker**: one for each side. To pivot wider and compute implied probability from decimal odds (`1 / price`), remove the overround (vig) by dividing each probability by the sum over all outcomes:
+
+```{r tidy_h2h}
+# Work with h2h (moneyline) only
+h2h <- nba_odds %>%
+  filter(market_key == "h2h")
+
+# Implied probability per outcome, before removing vig
+h2h_prob <- h2h %>%
+  group_by(id, bookmaker_key) %>%
+  mutate(
+    implied_prob_raw = 1 / outcomes_price,
+    total_overround  = sum(implied_prob_raw),
+    # Remove vig: normalise so probs sum to 1
+    implied_prob_fair = implied_prob_raw / total_overround
+  ) %>%
+  ungroup()
+
+h2h_prob %>%
+  select(home_team, away_team, bookmaker, outcomes_name,
+         outcomes_price, implied_prob_raw, implied_prob_fair) %>%
+  head(6)
+# home_team           away_team       bookmaker   outcomes_name       price  raw_prob  fair_prob
+# Los Angeles Lakers  Boston Celtics  DraftKings  Los Angeles Lakers  2.05   0.488     0.490
+# Los Angeles Lakers  Boston Celtics  DraftKings  Boston Celtics      1.90   0.526     0.510
+# Los Angeles Lakers  Boston Celtics  FanDuel     Los Angeles Lakers  2.00   0.500     0.499
+# Los Angeles Lakers  Boston Celtics  FanDuel     Boston Celtics      1.87   0.535     0.501
+```
+
+The `total_overround` column tells you each bookmaker's vig. A value of 1.05 means the bookmaker takes a 5% margin.
+
+### Line shopping: best available price per outcome
+
+```{r line_shopping}
+best_h2h <- h2h_prob %>%
+  group_by(id, home_team, away_team, outcomes_name) %>%
+  slice_max(outcomes_price, n = 1, with_ties = FALSE) %>%
+  select(home_team, away_team, outcomes_name, bookmaker, outcomes_price, implied_prob_fair) %>%
+  ungroup() %>%
+  arrange(home_team, outcomes_name)
+
+best_h2h
+# home_team           away_team       outcomes_name       bookmaker   price  fair_prob
+# Los Angeles Lakers  Boston Celtics  Boston Celtics      Bet365      1.95   0.505
+# Los Angeles Lakers  Boston Celtics  Los Angeles Lakers  DraftKings  2.10   0.492
+```
+
+### Handling spreads and totals
+
+Spreads and totals each have two rows per (event, bookmaker). The `outcomes_point` column carries the handicap or total line:
+
+```{r tidy_spreads}
+spreads <- nba_odds %>%
+  filter(market_key == "spreads") %>%
+  # Label each side more clearly
+  mutate(side = if_else(outcomes_point < 0, "favourite", "underdog"))
+
+# Best spread price per team across bookmakers
+best_spreads <- spreads %>%
+  group_by(id, home_team, away_team, outcomes_name) %>%
+  slice_max(outcomes_price, n = 1, with_ties = FALSE) %>%
+  select(home_team, away_team, outcomes_name, outcomes_point, bookmaker, outcomes_price)
+
+best_spreads
+# home_team           away_team       outcomes_name       outcomes_point  bookmaker   price
+# Los Angeles Lakers  Boston Celtics  Los Angeles Lakers  -3.5            BetMGM      1.95
+# Los Angeles Lakers  Boston Celtics  Boston Celtics      3.5             FanDuel     1.95
+```
+
+
+## 5. Historical odds — tracking line movement
+
+The historical endpoints require a paid plan. They use a snapshot model: supply an ISO 8601 `date` and get back the data state at the closest snapshot at or before that time.
+
+### Fetch a single historical snapshot
+
+```{r historical_single}
+# Spreads for an NBA game 48 hours before tip-off
+hist_odds_48h <- toa_sports_odds_history(
+  sport_key   = "basketball_nba",
+  date        = "2024-01-15T00:00:00Z",
+  regions     = "us",
+  markets     = "spreads",
+  odds_format = "decimal",
+  date_format = "iso"
+)
+
+hist_odds_48h %>%
+  select(timestamp, previous_timestamp, next_timestamp,
+         home_team, away_team, bookmaker, outcomes_name,
+         outcomes_price, outcomes_point) %>%
+  head(4)
+# timestamp                 prev_ts                    next_ts                    home_team         ...
+# 2024-01-14T23:58:00Z      2024-01-14T23:53:00Z       2024-01-15T00:03:00Z       Los Angeles Lakers
+```
+
+### Page through snapshots to build a line-movement dataset
+
+Use the `next_timestamp` from one response as the `date` parameter of the next call to walk forward in time. The cost for `toa_sports_odds_history()` is 10× the standard rate (10 × markets × regions per call), so plan accordingly.
+
+```{r historical_loop}
+# Build a 6-snapshot series for a specific event
+event_id   <- "93af4b300a4c0dded909234ea32e9abd"
+start_date <- "2024-01-13T12:00:00Z"
+n_snapshots <- 6
+
+snapshots <- list()
+current_date <- start_date
+
+for (i in seq_len(n_snapshots)) {
+  snap <- toa_event_odds_history(
+    sport_key   = "basketball_nba",
+    event_id    = event_id,
+    date        = current_date,
+    regions     = "us",
+    markets     = "spreads",
+    odds_format = "decimal",
+    date_format = "iso"
+  )
+
+  if (nrow(snap) == 0) break
+
+  snapshots[[i]] <- snap
+  current_date   <- snap$next_timestamp[[1]]
+
+  # Be kind to the API rate limit
+  Sys.sleep(0.5)
+}
+
+line_movement <- bind_rows(snapshots) %>%
+  filter(market_key == "spreads", bookmaker_key == "draftkings") %>%
+  select(timestamp, home_team, away_team, outcomes_name,
+         outcomes_price, outcomes_point)
+
+line_movement
+# timestamp                 home_team           away_team       outcomes_name       price  point
+# 2024-01-13T12:00:00Z      Los Angeles Lakers  Boston Celtics  Los Angeles Lakers  1.91   -4.5
+# 2024-01-13T17:00:00Z      Los Angeles Lakers  Boston Celtics  Los Angeles Lakers  1.91   -5.0
+# 2024-01-14T00:00:00Z      Los Angeles Lakers  Boston Celtics  Los Angeles Lakers  1.95   -5.5
+# ...
+```
+
+
+## 6. Persist and schedule — SQLite storage + quota-aware scheduling
+
+### Store snapshots to SQLite
+
+Use `DBI` + `RSQLite` to keep a running archive. Key each row by `pulled_at` so you can track when each snapshot was collected.
+
+```{r sqlite_persist}
+# --- one-time setup ---
+con <- dbConnect(RSQLite::SQLite(), "odds_archive.sqlite")
+
+# Create the table if it doesn't exist yet
+dbExecute(con, "
+  CREATE TABLE IF NOT EXISTS odds_snapshots (
+    pulled_at         TEXT,
+    snapshot_ts       TEXT,
+    event_id          TEXT,
+    sport_key         TEXT,
+    sport_title       TEXT,
+    commence_time     TEXT,
+    home_team         TEXT,
+    away_team         TEXT,
+    bookmaker_key     TEXT,
+    bookmaker         TEXT,
+    market_key        TEXT,
+    outcomes_name     TEXT,
+    outcomes_price    REAL,
+    outcomes_point    REAL
+  )
+")
+
+# --- called on each scheduled pull ---
+pull_and_store <- function(sport_key, regions = "us", markets = "h2h,spreads") {
+  pulled_at <- format(Sys.time(), "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")
+
+  raw <- toa_sports_odds(
+    sport_key   = sport_key,
+    regions     = regions,
+    markets     = markets,
+    odds_format = "decimal",
+    date_format = "iso"
+  )
+
+  if (nrow(raw) == 0) return(invisible(NULL))
+
+  to_store <- raw %>%
+    mutate(pulled_at = pulled_at) %>%
+    select(
+      pulled_at, snapshot_ts = bookmaker_last_update,
+      event_id = id, sport_key, sport_title,
+      commence_time, home_team, away_team,
+      bookmaker_key, bookmaker, market_key,
+      outcomes_name, outcomes_price,
+      # outcomes_point may be NA for h2h
+      outcomes_point = dplyr::any_of("outcomes_point")
+    )
+
+  dbAppendTable(con, "odds_snapshots", to_store)
+  cli::cli_alert_success("Stored {nrow(to_store)} rows at {pulled_at}.")
+}
+
+# Run the pull
+pull_and_store("basketball_nba")
+
+# When done for the session, close the connection
+dbDisconnect(con)
+```
+
+### Quota-aware scheduling
+
+The Odds API's quota resets monthly. Before each scheduled pull, check your remaining balance and bail early if you are running low:
+
+```{r quota_guard}
+safe_pull <- function(sport_key, min_remaining = 50, ...) {
+  budget <- toa_requests()
+  if (budget$requests_remaining < min_remaining) {
+    cli::cli_alert_warning(
+      "Only {budget$requests_remaining} credits remain -- skipping pull."
+    )
+    return(invisible(NULL))
+  }
+  pull_and_store(sport_key, ...)
+}
+```
+
+For cron-based scheduling (e.g. via `cronR` on Linux/macOS or Task Scheduler on Windows), a pull every 5 minutes for two markets across one region costs 2 credits per call. At 12 calls/hour × 24h × 30 days = 8,640 calls per month. Plan your pull frequency according to your plan's monthly quota.
+
+
+## 7. Visualize — best lines table and line-movement chart
+
+### Best-lines summary table with `gt`
+
+```{r gt_best_lines}
+best_lines_table <- best_h2h %>%
+  select(
+    Game      = home_team,
+    Opponent  = away_team,
+    Side      = outcomes_name,
+    Book      = bookmaker,
+    `Best Price` = outcomes_price,
+    `Fair Prob`  = implied_prob_fair
+  ) %>%
+  mutate(`Fair Prob` = scales::percent(`Fair Prob`, accuracy = 0.1)) %>%
+  gt() %>%
+  tab_header(
+    title    = "Best Available Moneyline (Decimal)",
+    subtitle = paste("Pulled:", format(Sys.time(), "%Y-%m-%d %H:%M UTC", tz = "UTC"))
+  ) %>%
+  fmt_number(columns = `Best Price`, decimals = 2) %>%
+  cols_align("center", columns = c(`Best Price`, `Fair Prob`))
+
+best_lines_table
+```
+
+### Line-movement chart with `ggplot2`
+
+```{r ggplot_line_movement}
+line_movement_chart <- line_movement %>%
+  mutate(timestamp = as.POSIXct(timestamp, format = "%Y-%m-%dT%H:%M:%SZ", tz = "UTC")) %>%
+  ggplot(aes(x = timestamp, y = outcomes_point,
+             colour = outcomes_name, group = outcomes_name)) +
+  geom_line(linewidth = 1) +
+  geom_point(size = 2) +
+  scale_colour_brewer(palette = "Set1", name = "Side") +
+  scale_x_datetime(date_labels = "%b %d\n%H:%M", date_breaks = "12 hours") +
+  labs(
+    title    = "DraftKings Spread Line Movement",
+    subtitle = paste(
+      unique(line_movement$home_team),
+      "vs.",
+      unique(line_movement$away_team)
+    ),
+    x = "Snapshot Time (UTC)",
+    y = "Spread Point (negative = favourite)",
+    caption = "Source: The Odds API via oddsapiR"
+  ) +
+  theme_minimal(base_size = 13) +
+  theme(legend.position = "bottom")
+
+line_movement_chart
+```
+
+
+## Closing notes: SportsDataverse
+
+`oddsapiR` is part of the [SportsDataverse](https://sportsdataverse.org/), a collection of open-source R and Python packages for sports analytics. Companion packages include:
+
+- [**cfbfastR**](https://cfbfastR.sportsdataverse.org/) — college football play-by-play
+- [**hoopR**](https://hoopR.sportsdataverse.org/) — men's basketball (NBA + MBB)
+- [**wehoop**](https://wehoop.sportsdataverse.org/) — women's basketball (WNBA + WBB)
+- [**fastRhockey**](https://fastRhockey.sportsdataverse.org/) — hockey (NHL + PHF/PWHL)
+- [**baseballr**](https://BillPetti.github.io/baseballr/) — baseball (MLB + NCAA)
+
+Each package follows the same tidy-data conventions, making it straightforward to join odds data from `oddsapiR` with play-by-play or box-score data from the other packages.
+
+File issues and feature requests at the [oddsapiR GitHub repository](https://github.com/sportsdataverse/oddsapiR/issues).

--- a/vignettes/oddsapiR.Rmd
+++ b/vignettes/oddsapiR.Rmd
@@ -2,7 +2,7 @@
 title: "Getting started with oddsapiR"
 author: "Saiem Gilani <br><a href='https://twitter.com/saiemgilani' target='blank'><img src='https://img.shields.io/twitter/follow/saiemgilani?color=blue&amp;label=%40saiemgilani&amp;logo=twitter&amp;style=for-the-badge' alt='@saiemgilani'/></a> <a href='https://github.com/saiemgilani' target='blank'><img src='https://img.shields.io/github/followers/saiemgilani?color=eee&amp;logo=Github&amp;style=for-the-badge' alt='@saiemgilani'/></a>"
 opengraph:
-  image: 
+  image:
     src: "https://github.com/saiemgilani/oddsapiR/blob/main/logo.png?raw=true"
   twitter:
     card: summary
@@ -14,7 +14,7 @@ output: html_document
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  fig.width=16, 
+  fig.width=16,
   fig.height=8
 )
 library(gtExtras)
@@ -27,7 +27,10 @@ Welcome folks,
 
 I'm Saiem Gilani, one of the [authors](https://saiemgilani.github.io/oddsapiR/authors.html "Authors and contributors to oddsapiR") of [`oddsapiR`](https://saiemgilani.github.io/oddsapiR/), and I hope to give the community a high-quality resource for accessing [**`The Odds API`**](https://the-odds-api.com/).
 
+`oddsapiR` provides a tidy R interface to [The Odds API](https://the-odds-api.com), covering sports discovery, events, live and historical odds, scores, and quota management. All functions return [`oddsapiR_data`](https://oddsapiR.sportsdataverse.org/reference/index.html) tibbles with quota metadata attached as attributes.
+
 ## **Install** [**`oddsapiR`**](https://saiemgilani.github.io/oddsapiR/)
+
 ```{r install_oddsapiR_gs, message=FALSE,eval=FALSE}
 # You can install using the pacman package using the following code:
 if (!requireNamespace('pacman', quietly = TRUE)){
@@ -39,73 +42,376 @@ pacman::p_load(dplyr, knitr, gt)
 ```
 
 
-#### **Odds API Keys**
+## **Odds API Keys**
 
 The [Odds API](https://the-odds-api.com) requires an API key, here's a quick run-down:
 
-* Using the key: You can save the key for consistent usage by adding `ODDS_API_KEY=XXXX-YOUR-API-KEY-HERE-XXXXX` to your .Renviron file (easily accessed via [**`usethis::edit_r_environ()`**](https://usethis.r-lib.org/reference/edit.html)). Run [**`usethis::edit_r_environ()`**](https://usethis.r-lib.org/reference/edit.html), a new script will pop open named `.Renviron`, **THEN** paste the following in the new script that pops up (with**out** quotations)
+* **Persistent usage:** Save the key for consistent usage by adding `ODDS_API_KEY=XXXX-YOUR-API-KEY-HERE-XXXXX` to your `.Renviron` file (easily accessed via [**`usethis::edit_r_environ()`**](https://usethis.r-lib.org/reference/edit.html)). Run `usethis::edit_r_environ()`, a new script will pop open named `.Renviron`, **THEN** paste the following in the new script that pops up (with**out** quotations):
+
 ```r
 ODDS_API_KEY = XXXX-YOUR-API-KEY-HERE-XXXXX
 ```
+
 Save the script and **restart your RStudio session**, by clicking `Session` (in between `Plots` and `Build`) and click `Restart R` (there also exists the shortcut `Ctrl + Shift + F10` to restart your session). If set correctly, from then on you should be able to use any of the functions without any other changes.
 
-* For less consistent usage: At the beginning of every session or within an R environment, save your API key as the environment variable `ODDS_API_KEY` (with quotations) using a command like the following.
+* **Session-level usage:** At the beginning of every session or within an R environment, save your API key as the environment variable `ODDS_API_KEY` (with quotations) using a command like the following.
 
 ```{r setenv_ex, message=FALSE, eval = FALSE}
 Sys.setenv(ODDS_API_KEY = "XXXX-YOUR-API-KEY-HERE-XXXXX")
 ```
 
+The helper functions `toa_key()`, `has_toa_key()`, and `check_toa_key()` let you inspect the key at any point.  `has_toa_key()` returns `TRUE`/`FALSE`; `check_toa_key()` stops with a helpful message when no key is found.
+
+```{r key_helpers, eval=FALSE}
+has_toa_key()      # TRUE / FALSE
+toa_key()          # the raw key string (or NA)
+check_toa_key()    # errors loudly if key is missing
+```
 
 
-### **The included data**
+## **How oddsapiR talks to The Odds API**
 
-```toa_sports_keys``` - The sports for which `The Odds API` provides coverage
+Every `toa_*()` function calls the same underlying HTTP layer in `R/utils.R`:
+
+1. **`toa_api_request(url, query)`** — builds an `httr2` request, attaches a standard user-agent (`oddsapiR/...`), applies a 3-try retry policy on transient network failures, and calls `httr2::req_perform()`.
+2. **`toa_api_call(url, query)`** — wraps `toa_api_request()`, reads the response body as a string, and parses it with `jsonlite::fromJSON()`. Used by every odds/events/scores endpoint.
+3. **`toa_api_headers(url, query)`** — wraps `toa_api_request()` and reads only the `x-requests-remaining` / `x-requests-used` headers. Used by `toa_requests()`.
+
+The base URL pattern for v4 is:
+
+```
+https://api.the-odds-api.com/v4/sports/{sport_key}/odds
+                                                  /events
+                                                  /participants
+                                                  /scores
+https://api.the-odds-api.com/v4/historical/sports/{sport_key}/odds
+                                                             /events
+```
+
+The API key is passed as the `apiKey` query parameter in every request.
+
+### **Quota tracking**
+
+Every successful response from The Odds API includes three headers:
+
+| Header | Meaning |
+|:---|:---|
+| `x-requests-remaining` | Credits remaining until the monthly quota resets |
+| `x-requests-used` | Credits consumed since the last quota reset |
+| `x-requests-last` | Cost of the most recent call |
+
+`oddsapiR` caches these after every call in a package-private environment (`.oddsapiR`). They are also attached as attributes to every returned tibble so they travel with the data:
+
+```{r quota_attrs, eval=FALSE}
+odds <- toa_sports_odds(sport_key = 'basketball_nba', regions = 'us', markets = 'h2h')
+
+# Inspect quota without making another call
+toa_quota()
+# # A tibble: 1 x 3
+# requests_remaining requests_used requests_last
+#              <int>         <int>         <int>
+#               9850           150             1
+
+attr(odds, "oddsapiR_requests_remaining")
+attr(odds, "oddsapiR_requests_used")
+attr(odds, "oddsapiR_requests_last")
+```
+
+The `print.oddsapiR_data()` method echoes these values when you print any result.
+
+### **Key parameters: regions, markets, odds_format**
+
+Most odds endpoints accept these three shared parameters:
+
+* **`regions`** — which bookmakers to include: `"us"`, `"us2"`, `"uk"`, `"eu"`, `"au"`. Comma-separate for multiple (`"us,uk"`). Each region counts as 1 unit in the usage quota multiplier.
+* **`markets`** — which betting lines to return: `"h2h"` (moneyline), `"spreads"` (point handicap), `"totals"` (over/under), `"outrights"` (futures). Comma-separate for multiple (`"h2h,spreads"`). Each market counts as 1 unit in the quota multiplier.
+* **`odds_format`** — `"decimal"` (default) or `"american"`.
+
+**Quota cost** for `toa_sports_odds()` = number of markets × number of regions. So pulling `"h2h,spreads,totals"` across `"us,uk"` costs 3 × 2 = 6 credits.
+
+### **Historical endpoints and the snapshot model**
+
+`toa_sports_odds_history()`, `toa_sports_events_history()`, and `toa_event_odds_history()` operate on a snapshot model: you supply an ISO 8601 `date` timestamp and the API returns the state of the data at the closest snapshot equal to or earlier than that time. The response always includes `timestamp`, `previous_timestamp`, and `next_timestamp` columns so you can page through the archive programmatically.
+
+
+## **The included data**
+
+`toa_sports_keys` is a bundled data frame listing all sports the API covers. This data requires no API key and no network access — it is included in the package:
+
 ```{r toa_sports_keys_table}
 oddsapiR::toa_sports_keys %>%
-  gt() %>% 
+  gt() %>%
   gtExtras::gt_theme_538(table.width = px(650))
-
 ```
 
-### **Three core functions**
-One endpoint for looking up the sports the API provides (including currently `active` status): ```toa_sports```
-```{r toa_sports_call}
 
-oddsapiR::toa_sports(all_sports = TRUE) %>%
-  head(n=10) %>% 
-  gt() %>% 
-  gtExtras::gt_theme_538(table.width = px(550))
+## **Function reference by family**
 
+### **Sports & Events**
+
+#### `toa_sports()` — Discover active sports
+
+Returns all sports the API covers (or only in-season ones). The `key` column is the `sport_key` parameter used by every other function. Free — does not count against your quota.
+
+```{r toa_sports_call, eval=FALSE}
+sports <- toa_sports(all_sports = TRUE)
+# Returns a tibble with columns:
+#   key, group, title, description, active, has_outrights
+#
+# key              group                title         active
+# basketball_nba   Basketball           NBA           TRUE
+# soccer_epl       Soccer               EPL           TRUE
+# ...
 ```
 
-One endpoint for looking up the current odds from the API: ```toa_sports_odds```
-```{r toa_sports_odds_call}
-oddsapiR::toa_sports_odds(sport_key = 'basketball_nba', 
-                          regions = 'us', 
-                          markets = 'spreads', 
-                          odds_format = 'decimal',
-                          date_format = 'iso') %>% 
-  dplyr::select(c("bookmaker","market_key", "outcomes_name","outcomes_price","outcomes_point","home_team","away_team","commence_time")) %>% 
-  head(n=20) %>% 
-  knitr::kable()
-```
-Note: There are two entries per event per bookmaker for the spreads for both sides of the event.
+#### `toa_sports_events()` — List upcoming events for a sport
 
-One endpoint for looking up the current scores from the API: ```toa_sports_scores```
-```{r toa_sports_scores_call}
-oddsapiR::toa_sports_scores(sport_key = 'basketball_nba', 
-                            days_from = NULL,
-                            date_format = 'iso') %>% 
-  head(n=20) %>% 
-  knitr::kable()
+Returns upcoming and in-play events (without odds). The `id` column from this result is the `event_id` used by `toa_event_odds()` and `toa_event_markets()`. Free — does not count against your quota.
 
+```{r toa_sports_events_call, eval=FALSE}
+events <- toa_sports_events(
+  sport_key          = 'basketball_nba',
+  date_format        = 'iso',
+  commence_time_from = '2025-01-15T00:00:00Z',
+  commence_time_to   = '2025-01-16T00:00:00Z'
+)
+# Returns a tibble: id, sport_key, sport_title, commence_time, home_team, away_team
+#
+# id                                sport_key       home_team          away_team
+# 48db9c3293a52baab881d95d38f37a98  basketball_nba  Los Angeles Lakers  Boston Celtics
 ```
 
+#### `toa_sports_participants()` — List participants (teams or players) for a sport
+
+Returns the whitelist of teams or individual competitors for a sport. Cost: 1 credit.
+
+```{r toa_sports_participants_call, eval=FALSE}
+participants <- toa_sports_participants(sport_key = 'basketball_nba')
+# Returns a tibble: sport_key, id, full_name
+#
+# sport_key       id                              full_name
+# basketball_nba  par_01hqmkq6fdf1pvq7jgdd7hdmpf  Los Angeles Lakers
+# basketball_nba  par_01hqmkq6fdf1pvq7jgdd7hdmpe  Boston Celtics
+```
+
+#### `toa_sports_scores()` — Live and recent scores
+
+Returns live and recently completed games with scores (updated ~30s for live games; covers completed games within the last 3 days). Cost: 1 credit without `days_from`, 2 credits with it.
+
+```{r toa_sports_scores_call, eval=FALSE}
+scores <- toa_sports_scores(
+  sport_key   = 'basketball_nba',
+  days_from   = 1,          # include games completed in the last 1 day
+  date_format = 'iso'
+)
+# Returns a tibble:
+#   id, sport_key, sport_title, commence_time, completed, home_team, away_team,
+#   scores (list-col of name/score pairs), last_update
+```
+
+
+### **Current Odds & Markets**
+
+#### `toa_sports_odds()` — Featured-market odds across all events for a sport
+
+The primary odds endpoint. Returns a **long-format** tibble — one row per (event, bookmaker, market, outcome). Cost = markets × regions.
+
+```{r toa_sports_odds_call, eval=FALSE}
+odds <- toa_sports_odds(
+  sport_key   = 'basketball_nba',
+  regions     = 'us',
+  markets     = 'h2h,spreads,totals',
+  odds_format = 'decimal',
+  date_format = 'iso'
+)
+# Returns columns:
+#   id, sport_key, sport_title, commence_time, home_team, away_team,
+#   bookmaker_key, bookmaker, bookmaker_last_update,
+#   market_key, market_last_update,
+#   outcomes_name, outcomes_price, outcomes_point
+#
+# Note: spreads and totals have TWO rows per event per bookmaker
+#       (one for each side / Over / Under).
+```
+
+#### `toa_event_odds()` — Full market depth for a single event
+
+Like `toa_sports_odds()` but scoped to one game and supports **all** available market keys, including player props (`player_points`, `player_pass_tds`, `player_shots_on_goal`, etc.) and alternate lines. Look up `event_id` first with `toa_sports_events()`.
+
+```{r toa_event_odds_call, eval=FALSE}
+event_odds <- toa_event_odds(
+  sport_key   = 'basketball_nba',
+  event_id    = '48db9c3293a52baab881d95d38f37a98',
+  regions     = 'us',
+  markets     = 'player_points',   # player props
+  odds_format = 'decimal',
+  date_format = 'iso'
+)
+# Adds outcomes_description column (player name for props)
+```
+
+You can also target specific bookmakers with the `bookmakers` parameter (comma-separated slugs like `"draftkings,fanduel"`). When `bookmakers` and `regions` are both supplied, `bookmakers` takes precedence.
+
+#### `toa_event_markets()` — Discover available market keys for a game
+
+Returns the recently-seen market keys per bookmaker for a single event (no odds). Use the returned `market_key` values to then request odds via `toa_event_odds()`. Cost: 1 credit.
+
+```{r toa_event_markets_call, eval=FALSE}
+markets <- toa_event_markets(
+  sport_key = 'basketball_nba',
+  event_id  = '48db9c3293a52baab881d95d38f37a98',
+  regions   = 'us'
+)
+# Returns: id, sport_key, sport_title, commence_time, home_team, away_team,
+#          bookmaker_key, bookmaker, market_key, market_last_update
+#
+# Typical market_key values: h2h, spreads, totals, player_points,
+#                             player_rebounds, player_assists, ...
+```
+
+
+### **Historical Odds & Events (paid plans)**
+
+Historical endpoints return the API state at a point in time. All three accept an ISO 8601 `date` string and respond with the snapshot closest to (and not after) that time. The `timestamp`, `previous_timestamp`, and `next_timestamp` columns in the result let you page through the archive.
+
+Historical data covers featured markets back to June 2020, and additional markets (props, alternate lines) from 2023-05-03 at 5-minute intervals.
+
+#### `toa_sports_odds_history()` — Historical featured-market odds for a sport
+
+```{r toa_sports_odds_history_call, eval=FALSE}
+hist_odds <- toa_sports_odds_history(
+  sport_key   = 'basketball_nba',
+  date        = '2024-01-15T12:15:00Z',
+  regions     = 'us',
+  markets     = 'spreads',
+  odds_format = 'decimal',
+  date_format = 'iso'
+)
+# Returns same columns as toa_sports_odds() plus:
+#   timestamp, previous_timestamp, next_timestamp
+#
+# Cost: 10 x markets x regions (10x historical multiplier)
+```
+
+#### `toa_sports_events_history()` — Historical event list (no odds)
+
+```{r toa_sports_events_history_call, eval=FALSE}
+hist_events <- toa_sports_events_history(
+  sport_key = 'basketball_nba',
+  date      = '2024-01-15T12:15:00Z'
+)
+# Returns same columns as toa_sports_events() plus:
+#   timestamp, previous_timestamp, next_timestamp
+#
+# Cost: 1 credit
+```
+
+#### `toa_event_odds_history()` — Historical odds for a single event
+
+Like `toa_event_odds()` for a specific snapshot time. Accepts player props and alternate markets.
+
+```{r toa_event_odds_history_call, eval=FALSE}
+hist_event_odds <- toa_event_odds_history(
+  sport_key   = 'basketball_nba',
+  event_id    = '93af4b300a4c0dded909234ea32e9abd',
+  date        = '2024-01-15T12:15:00Z',
+  regions     = 'us',
+  markets     = 'h2h',
+  odds_format = 'decimal',
+  date_format = 'iso'
+)
+# Returns same columns as toa_event_odds() plus:
+#   timestamp, previous_timestamp, next_timestamp
+#
+# Cost: markets x regions (standard rate, no 10x multiplier for event-level)
+```
+
+
+### **Account & Usage**
+
+#### `toa_quota()` — Inspect your current quota balance
+
+Returns a one-row tibble read from the headers of the **most recent** API call made in this R session. Calling `toa_quota()` does not itself use a quota credit.
+
+```{r toa_quota_call, eval=FALSE}
+# After any toa_* call:
+toa_quota()
+# # A tibble: 1 x 3
+#   requests_remaining requests_used requests_last
+#                <int>         <int>         <int>
+#                 9850           150             1
+```
+
+#### `toa_requests()` — Fetch quota from the API directly
+
+Hits the free `/v4/sports` endpoint specifically to read the current quota balance from the response headers. Use this at the start of a session to check your budget before pulling odds.
+
+```{r toa_requests_call, eval=FALSE}
+toa_requests()
+# # A tibble: 1 x 2
+#   requests_remaining requests_used
+#                <int>         <int>
+#                 9850           150
+```
+
+#### Key helpers: `toa_key()`, `has_toa_key()`, `check_toa_key()`
+
+```{r key_helpers2, eval=FALSE}
+toa_key()         # Returns the ODDS_API_KEY env var or NA_character_
+has_toa_key()     # Returns TRUE if key is set, FALSE otherwise
+check_toa_key()   # Stops with a clear error if key is missing
+```
+
+
+## **Worked example — pulling moneyline odds**
+
+This minimal example shows the basic pattern: check quota first, pull odds, inspect the result.
+
+```{r worked_example, eval=FALSE}
+library(oddsapiR)
+library(dplyr)
+
+# 1. Verify a key exists and check starting budget
+check_toa_key()
+toa_requests()
+# requests_remaining = 500, requests_used = 0
+
+# 2. Pull moneyline (h2h) odds for the NBA from US books
+nba_h2h <- toa_sports_odds(
+  sport_key   = "basketball_nba",
+  regions     = "us",
+  markets     = "h2h",
+  odds_format = "decimal",
+  date_format = "iso"
+)
+
+# 3. Inspect: one row per (event x bookmaker x outcome)
+glimpse(nba_h2h)
+# Rows: ~120
+# Columns: id, sport_key, sport_title, commence_time, home_team, away_team,
+#           bookmaker_key, bookmaker, bookmaker_last_update,
+#           market_key, market_last_update, outcomes_name, outcomes_price
+
+# 4. Find the best moneyline price for each team across all books
+best_lines <- nba_h2h %>%
+  group_by(home_team, away_team, outcomes_name) %>%
+  slice_max(outcomes_price, n = 1) %>%
+  select(home_team, away_team, outcomes_name, bookmaker, outcomes_price)
+
+best_lines
+# home_team           away_team      outcomes_name       bookmaker    outcomes_price
+# Los Angeles Lakers  Boston Celtics Los Angeles Lakers  DraftKings            2.05
+# Los Angeles Lakers  Boston Celtics Boston Celtics      FanDuel               1.87
+
+# 5. Check how much that cost
+toa_quota()
+# requests_remaining = 499, requests_used = 1, requests_last = 1
+```
 
 
 ## **Our Authors**
 
--   [Saiem Gilani](https://twitter.com/saiemgilani)       
+-   [Saiem Gilani](https://twitter.com/saiemgilani)
 <a href="https://twitter.com/saiemgilani" target="blank"><img src="https://img.shields.io/twitter/follow/saiemgilani?color=blue&label=%40saiemgilani&logo=twitter&style=for-the-badge" alt="@saiemgilani" /></a>
 <a href="https://github.com/saiemgilani" target="blank"><img src="https://img.shields.io/github/followers/saiemgilani?color=eee&logo=Github&style=for-the-badge" alt="@saiemgilani" /></a>
 


### PR DESCRIPTION
## Summary

Brings oddsapiR's documentation up to the SportsDataverse family standard: comparable badges, modernized citations, function cross-linking, an expanded tutorial + a new pipeline article, and a refreshed SDV network menu.

## Changes

**Badges** (added via `usethis::use_badge()` so they sit between the `<!-- badges -->` markers and populate pkgdown's sidebar): added **CRAN version**, **CRAN downloads**, and **R-universe** badges alongside the existing Version-Number / R-CMD-check / Lifecycle / Contributors / Twitter, reordered to the SDV convention; Twitter logo modernized to `x`.

**README**: removed a stray empty heading, added a real package intro + a **SportsDataverse family** cross-link table, and uncommented the CRAN install instructions (oddsapiR is on CRAN). README.md re-rendered via `devtools::build_readme()`.

**Citations**: modernized `inst/CITATION` from the deprecated `citEntry()`/`personList()` to `bibentry()`/`person()`, with a Date-less year fallback (avoids the R CMD check NOTE).

**Cross-linking**: added `@family` + `@seealso` to all 15 exported functions, grouped as *Sports & Events*, *Odds & Markets*, *Historical*, and *Account & Usage*, so the pkgdown reference auto-links related functions. `man/` regenerated; `devtools::check_man()` clean.

**Tutorials**:
- Expanded `vignettes/oddsapiR.Rmd` to cover **every** endpoint by family, plus a new "How oddsapiR talks to The Odds API" section (the `httr2` request layer, `ODDS_API_KEY` resolution, quota headers / `toa_quota()`, regions/markets/odds_format params, and the historical snapshot model).
- New article **`Building a sports-odds pipeline`**: discover → pull odds across bookmakers → tidy + de-vig + line-shop → historical line movement → SQLite persistence + quota-aware scheduling → `gt`/`ggplot2` visualization.
- All live-API chunks are `eval = FALSE` (CRAN/pkgdown safe); only the offline `toa_sports_keys` table runs.

**pkgdown network menu**: synced to the current canonical SDV package list — adds oddsapiR, softballR, nwslR, usfootballR, hockeyR, ggshakeR, sportypy, recruitR-py, collegebaseball, soccerAnimate, nwslpy, and fixes stale URLs (cfbplotR, cfb4th, mlbplotR).

## Checks
- `devtools::check_man()` — clean
- `devtools::build_readme()` — README.md regenerated
- `_pkgdown.yml` parses; both Rmd front-matters valid

Docs-only; no exported behavior changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced cross-references and organization across function documentation
  * Expanded getting-started guide with detailed setup and usage information
  * Added comprehensive guide for building sports odds pipelines with practical examples
  * Improved README with clearer installation instructions and package ecosystem overview
  * Enhanced documentation website navigation and structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->